### PR TITLE
C++17

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,4 @@
-Checks: "*,-fuchsia-*,-google-*,-zircon-*,-abseil-*,-llvm*"
+Checks: "*,-fuchsia-*,-altera-*,-google-*,-zircon-*,-abseil-*,-llvm*,-readability-identifier-length,-cppcoreguidelines-pro-bounds-constant-array-index,-misc-non-private-member-variables-in-classes"
 CheckOptions:
 - key: cppcoreguidelines-special-member-functions.AllowSoleDefaultDtor
   value: true

--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Install Dependencies
+## Required 
+- C++ Compiler (here clang)
+- GMP
+
+`sudo apt install clang-15 libgmp-dev`
+## Optional 
+- OpenMP Support for the Compiler (here clang)
+- doxygen components 
+    - dot (graphviz) 
+    - mscgen
+    - dia
+
+`sudo apt install libomp-15-dev graphviz`

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.20)
 # set the project name
 project(PWP VERSION 1.0)
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 find_library(libgmp gmp REQUIRED)

--- a/src/ExtraOperators.hpp
+++ b/src/ExtraOperators.hpp
@@ -10,8 +10,9 @@ auto operator<<(std::ostream& out, const std::vector<T>& vec) -> std::ostream& {
   out << "[";
   for (std::size_t i = 0; i < vec.size(); ++i) {
     out << vec[i];
-    if (i != vec.size() - 1)
+    if (i != vec.size() - 1) {
       out << ", ";
+    }
   }
   out << "]";
   return out;
@@ -23,8 +24,9 @@ auto operator<<(std::ostream& out, const std::array<T, size>& arr) -> std::ostre
   out << "[";
   for (std::size_t i = 0; i < size; ++i) {
     out << arr[i];
-    if (i != size - 1)
+    if (i != size - 1) {
       out << ", ";
+    }
   }
   out << "]";
   return out;

--- a/src/PowersWithoutPowersFinder.cpp
+++ b/src/PowersWithoutPowersFinder.cpp
@@ -8,20 +8,23 @@
 using namespace std;
 
 auto PowersWithoutPowersFinder::findInRange(unsigned long n_start, unsigned long n_end) -> vector<unsigned long> {
-  Integer n_I, k_I;
+  Integer n_I;
+  Integer k_I;
   unsigned long k;
-  if (n_start % 4 != 0)
+  if (n_start % 4 != 0) {
     n_start += 4 - n_start % 4;
+  }
   for (unsigned long n = n_start; n < n_end; n += 4) {
-    if (forbiddenClasses.containsN(n))
+    if (forbiddenClasses.containsN(n)) {
       continue;
+    }
     n_I = n;
     k_I = SuffixMath::powContainsPows(2, n_I);
     Stats::updateK(k_I);
     // cout << Stats::maxK.get_str() << "\n";
-    if (k_I == 0)
+    if (k_I == 0) {
       matches.push_back(n);
-    else {
+    } else {
       if (k_I.fits_ulong_p()) {
         k = k_I.get_ui();
         forbiddenClasses.insert(n, k);
@@ -34,11 +37,11 @@ auto PowersWithoutPowersFinder::findInRange(unsigned long n_start, unsigned long
   return Getmatches();
 }
 
-auto PowersWithoutPowersFinder::GetforbiddenClasses() -> vector<SuffixClass> {
+auto PowersWithoutPowersFinder::GetforbiddenClasses() const -> vector<SuffixClass> {
   vector<SuffixClass> v = forbiddenClasses.toVector();
-  v.push_back(SuffixClass(1, 1));
-  v.push_back(SuffixClass(1, 2));
-  v.push_back(SuffixClass(1, 3));
+  v.emplace_back(1, 1);
+  v.emplace_back(1, 2);
+  v.emplace_back(1, 3);
   return v;
 }
 
@@ -52,7 +55,9 @@ auto PowersWithoutPowersFinder::finitenessProvable() -> bool {
 
 void PowersWithoutPowersFinder::timeTable(unsigned long maxN) {
   PowersWithoutPowersFinder pwp = PowersWithoutPowersFinder();
-  cout << "\n" << "Forbidden Classes" << "\n";
+  cout << "\n"
+       << "Forbidden Classes"
+       << "\n";
   printf("|%10s|%8s|%10s|%10s|\n", "N", "HH:MM:SS", "Matches", "Classes");
   auto t_start = time(nullptr);
   for (unsigned long n_start = 1, n_stop = 512000; n_stop < maxN; n_start = n_stop, n_stop *= 2) {

--- a/src/PowersWithoutPowersFinder.hpp
+++ b/src/PowersWithoutPowersFinder.hpp
@@ -17,12 +17,12 @@ class PowersWithoutPowersFinder {
    * \return Returns a vector of all forbidden suffix classes that could be
    * found so far
    */
-  auto GetforbiddenClasses() -> std::vector<SuffixClass>;
+  [[nodiscard]] auto GetforbiddenClasses() const -> std::vector<SuffixClass>;
 
   /**
    * \return Returns the biggest exponent that has been tested so far
    */
-  auto GetmaxTestedN() -> unsigned long { return maxTestedN; };
+  [[nodiscard]] auto GetmaxTestedN() const -> unsigned long { return maxTestedN; };
 
   /** Finds all matches in the range [n_start, n_end)
    *  UNSAVE, ONLY CALL IF MATCHES AND FORBIDDENCLASSES SETUP PROPERLY.
@@ -32,14 +32,14 @@ class PowersWithoutPowersFinder {
    */
   auto findInRange(unsigned long n_start, unsigned long n_end) -> std::vector<unsigned long>;
 
-  /** Finds all matches in the range [1, n_end], starts searching at maxTestedN + 1 
+  /** Finds all matches in the range [1, n_end], starts searching at maxTestedN + 1
    * \param n_end biggest exponent to be tested is n_end-1 \return Returns
    * all matches in that range
    */
   inline auto findUntil(unsigned long n_end) -> std::vector<unsigned long> { return findInRange(maxTestedN + 1, n_end); };
 
   /** Finds all matches in the range [1, C(k)], with smallest k such that C(k) >
-   * maxTestedN. Starts searching at maxTestedN + 1 
+   * maxTestedN. Starts searching at maxTestedN + 1
    * \return Returns all matches
    * in that range
    */
@@ -54,13 +54,13 @@ class PowersWithoutPowersFinder {
   /** Prints a small benchmark table
    * \param maxN upper bound for N for the benchmark
    */
-  static void timeTable(unsigned long maxN = 100000000);
+  static void timeTable(unsigned long maxN = 100000000);  // NOLINT
 
  protected:
  private:
-  std::vector<ulong> matches;    //!< A match is an exponent n such that 2^n
-                                 //!< contains no 1,2,4 or 8 as digit
-  SuffixSet forbiddenClasses;    //!< Member variable "forbiddenClasses"
-  unsigned long maxTestedN = 0;  //!< Maximal exponent that has been tested, all matches and forbidden
-                                 //!< classes are up to date
+  std::vector<unsigned long> matches;  //!< A match is an exponent n such that 2^n
+                                       //!< contains no 1,2,4 or 8 as digit
+  SuffixSet forbiddenClasses;          //!< Member variable "forbiddenClasses"
+  unsigned long maxTestedN = 0;        //!< Maximal exponent that has been tested, all matches and forbidden
+                                       //!< classes are up to date
 };

--- a/src/PowersWithoutPowersFinder_Test.hpp
+++ b/src/PowersWithoutPowersFinder_Test.hpp
@@ -5,9 +5,10 @@
 #include "PowersWithoutPowersFinder.hpp"
 
 namespace PowersWithoutPowersFinder_Test {
-auto Test() -> bool {
+inline auto Test() -> bool {
   using namespace std;
-  cout << " --- Testing PowersWithoutPowersFinder --- " << "\n";
+  cout << " --- Testing PowersWithoutPowersFinder --- "
+       << "\n";
   bool success = true;
   bool test = true;
 
@@ -23,11 +24,12 @@ auto Test() -> bool {
   std::vector<unsigned long> matches = pwp.Getmatches();
   std::vector<SuffixClass> forbidden = pwp.GetforbiddenClasses();
   std::sort(forbidden.begin(), forbidden.end());
-  std::vector<unsigned long> m = {16};
-  std::vector<SuffixClass> f = {SuffixClass(1_mpz, 1_mpz), SuffixClass(1_mpz, 2_mpz),  SuffixClass(1_mpz, 3_mpz), SuffixClass(2_mpz, 4_mpz),
-                                SuffixClass(3_mpz, 8_mpz), SuffixClass(4_mpz, 12_mpz), SuffixClass(4_mpz, 20_mpz)};
-  test &= (matches == m);
-  test &= (forbidden == f);
+  std::vector<unsigned long> matchesCorrect = {16};
+  std::vector<SuffixClass> forbiddenCorrect = {SuffixClass(1_mpz, 1_mpz), SuffixClass(1_mpz, 2_mpz), SuffixClass(1_mpz, 3_mpz),
+                                               SuffixClass(2_mpz, 4_mpz), SuffixClass(3_mpz, 8_mpz), SuffixClass(4_mpz, 12_mpz),
+                                               SuffixClass(4_mpz, 20_mpz)};
+  test &= (matches == matchesCorrect);
+  test &= (forbidden == forbiddenCorrect);
   success &= test;
   cout << (test ? "success" : "failed") << "\n";
   cout << "Matches " << matches << "\n";
@@ -38,7 +40,8 @@ auto Test() -> bool {
   success &= test;
   cout << ((test ? "success" : "failed")) << "\n";
 
-  cout << " --- Overall " << (success ? "success --- " : "failed --- ") << "\n" << "\n";
+  cout << " --- Overall " << (success ? "success --- " : "failed --- ") << "\n"
+       << "\n";
   return success;
 }
 }  // namespace PowersWithoutPowersFinder_Test

--- a/src/PowersWithoutPowersWorklist.cpp
+++ b/src/PowersWithoutPowersWorklist.cpp
@@ -11,8 +11,9 @@
 using namespace std;
 
 void PowersWithoutPowersWorklist::resetAll() {
-  for (auto& wl : worklist)
-    wl.clear();
+  for (auto& worklistForCurrentCycle : worklist) {
+    worklistForCurrentCycle.clear();
+  }
   unexpanded.clear();
   matches.clear();
   level = 1;
@@ -23,17 +24,20 @@ void PowersWithoutPowersWorklist::resetAll() {
 }
 
 void PowersWithoutPowersWorklist::setForbiddenDigits(const vector<int>& digits) {
-  for (int i = 0; i < 10; i++)
-    forbiddenDigits[i] = false;
-  for (int i : digits)
-    forbiddenDigits[i] = true;
+  for (int digit = 0; digit < NUM_DIGITS_I; digit++) {
+    forbiddenDigits[digit] = false;
+  }
+  for (int digit : digits) {
+    forbiddenDigits[digit] = true;
+  }
 }
 auto PowersWithoutPowersWorklist::getForbiddenDigits() -> vector<int> {
   vector<int> digits;
   ;
-  for (int i = 0; i < 10; i++) {
-    if (forbiddenDigits[i])
-      digits.push_back(i);
+  for (int digit = 0; digit < NUM_DIGITS_I; digit++) {
+    if (forbiddenDigits[digit]) {
+      digits.push_back(digit);
+    }
   }
   return digits;
 }
@@ -53,14 +57,16 @@ auto PowersWithoutPowersWorklist::run(unsigned max_level) -> vector<unsigned lon
         if (k_child == 0) {
           matches.push_back(n);
           if (isInWLRange(n)) {
-            for (unsigned long k_parent = level; k_parent < n; k_parent++)
+            for (unsigned long k_parent = level; k_parent < n; k_parent++) {
               expand1(n, k_parent, getWL(k_parent + 1));
+            }
           } else {
             unexpanded.push_back(n);
           }
         } else if (isInWLRange(k_child)) {
-          for (unsigned long k_parent = level; k_parent < k_child; k_parent++)
+          for (unsigned long k_parent = level; k_parent < k_child; k_parent++) {
             expand1(n, k_parent, getWL(k_parent + 1));
+          }
         } else {
           unexpanded.push_back(n);
         }
@@ -111,14 +117,16 @@ auto PowersWithoutPowersWorklist::runDFS(unsigned max_level) -> vector<unsigned 
       if (k_child == 0) {
         matches.push_back(n);
         if (isInWLRange(n)) {
-          for (unsigned long k_parent = level; k_parent < n; k_parent++)
+          for (unsigned long k_parent = level; k_parent < n; k_parent++) {
             expand1(n, k_parent, getWL(k_parent + 1));
+          }
         } else {
           unexpanded.push_back(n);
         }
       } else if (isInWLRange(k_child)) {
-        for (unsigned long k_parent = level; k_parent < k_child; k_parent++)
+        for (unsigned long k_parent = level; k_parent < k_child; k_parent++) {
           expand1(n, k_parent, getWL(k_parent + 1));
+        }
       } else {
         unexpanded.push_back(n);
       }
@@ -133,10 +141,12 @@ auto PowersWithoutPowersWorklist::runDFS(unsigned max_level) -> vector<unsigned 
 #ifdef _OPENMP
 auto PowersWithoutPowersWorklist::runParallel(unsigned max_level) -> vector<unsigned long> {
   size_t N = omp_get_max_threads();
-  while (level <= max_level and getWL(level).size() < N * 10)
+  while (level <= max_level and getWL(level).size() < N * 10) {
     run(level + 1);
-  if (level == max_level)
+  }
+  if (level == max_level) {
     return matches;
+  }
 #pragma omp parallel default(shared)
   {
     PowersWithoutPowersWorklist pwp_thread;
@@ -157,8 +167,9 @@ auto PowersWithoutPowersWorklist::runParallel(unsigned max_level) -> vector<unsi
 #pragma omp barrier
 #pragma omp single
     {
-      for (size_t wl = level; wl <= max_level; wl++)
+      for (size_t wl = level; wl <= max_level; wl++) {
         getWL(wl).clear();
+      }
     }
     for (size_t wl = level + 1; wl <= K_MAX_FOR_ULONG; wl++) {
 #pragma omp critical(combineWorklists)
@@ -183,38 +194,43 @@ auto PowersWithoutPowersWorklist::runParallel(unsigned max_level) -> vector<unsi
 #endif  //_OPENMP
 
 auto PowersWithoutPowersWorklist::isComplete() -> bool {
-  if (not unexpanded.empty())
+  if (not unexpanded.empty()) {
     return false;
+  }
   for (level = 1; level <= K_MAX_FOR_ULONG; level++) {
-    if (not getWL(level).empty())
+    if (not getWL(level).empty()) {
       return false;
+    }
   }
   return true;
 }
 
 void PowersWithoutPowersWorklist::expand1(unsigned long r, unsigned long k, vector<unsigned long>& worklist) {
   unsigned long m = SuffixMath::cycleLen(k);
-  for (; r < SuffixMath::cycleEnd(k); r += m)
-    ;
-  for (; r < SuffixMath::cycleStart(k + 1); r += m)
-    ;
-  for (int i = 0; i < 4; i++, r += m)
+  for (; r < SuffixMath::cycleEnd(k); r += m) {
+  }
+  for (; r < SuffixMath::cycleStart(k + 1); r += m) {
+  }
+  for (int i = 0; i < 4; i++, r += m) {
     worklist.push_back(r);
+  }
 }
 
 void PowersWithoutPowersWorklist::expand(unsigned long r, unsigned long k, unsigned long k_child, vector<unsigned long>& worklist) {
   unsigned long m = SuffixMath::cycleLen(k);
-  for (; r < SuffixMath::cycleEnd(k); r += m)
-    ;
-  for (; r < SuffixMath::cycleStart(k_child); r += m)
-    ;
-  for (; r < SuffixMath::cycleEnd(k_child); r += m)
+  for (; r < SuffixMath::cycleEnd(k); r += m) {
+  }
+  for (; r < SuffixMath::cycleStart(k_child); r += m) {
+  }
+  for (; r < SuffixMath::cycleEnd(k_child); r += m) {
     worklist.push_back(r);
+  }
 }
 
 void PowersWithoutPowersWorklist::timeTableRun(unsigned long maxK) {
   PowersWithoutPowersWorklist pwp = PowersWithoutPowersWorklist();
-  cout << "Worklist" << "\n";
+  cout << "Worklist"
+       << "\n";
   printf("|%10s|%8s|%10s|%10s|\n", "N", "HH:MM:SS", "Matches", "Unexpanded");
   auto t_start = time(nullptr);
   for (unsigned max_level = 1; max_level <= maxK; max_level++) {
@@ -236,7 +252,8 @@ void PowersWithoutPowersWorklist::timeTableRun(unsigned long maxK) {
 #ifdef _OPENMP
 void PowersWithoutPowersWorklist::timeTableRunParallel(unsigned long maxK) {
   PowersWithoutPowersWorklist pwp = PowersWithoutPowersWorklist();
-  cout << "Worklist parallel  (x" << omp_get_max_threads() << ")" << "\n";
+  cout << "Worklist parallel  (x" << omp_get_max_threads() << ")"
+       << "\n";
   printf("|%10s|%8s|%10s|%10s|\n", "N", "HH:MM:SS", "Matches", "Unexpanded");
   auto t_start = time(nullptr);
   for (unsigned max_level = 1; max_level <= maxK; max_level++) {
@@ -256,15 +273,18 @@ void PowersWithoutPowersWorklist::timeTableRunParallel(unsigned long maxK) {
 }
 
 void PowersWithoutPowersWorklist::speedUpTable(unsigned long minK, unsigned long maxK) {
-  chrono::time_point<chrono::steady_clock> t_start, t_end;
+  chrono::time_point<chrono::steady_clock> t_start;
+  chrono::time_point<chrono::steady_clock> t_end;
 
-  cout << "Worklist speedUp" << "\n";
+  cout << "Worklist speedUp"
+       << "\n";
   vector<int> parLevelNumThreads = {0, 1, 2, 4, 8, 16, 18, 32, 64, 128, 144};
   vector<const char*> parLevel = {"No OMP", "x1", "x2", "x4", "x8", "x16", "x18", "x32", "x64", "x128", "x144"};
   vector<vector<unsigned>> t(parLevel.size());
 
   // ---Timetable---
-  cout << "Runtime [ms]" << "\n";
+  cout << "Runtime [ms]"
+       << "\n";
   // Header Line
   printf("|%14s|", "N");
   for (const char* s : parLevel)
@@ -295,7 +315,8 @@ void PowersWithoutPowersWorklist::speedUpTable(unsigned long minK, unsigned long
   cout << "\n";
 
   // ---Speedup  table---
-  cout << "Speedup" << "\n";
+  cout << "Speedup"
+       << "\n";
   // Header Line
   printf("|%14s|", "N");
   for (const char* s : parLevel)
@@ -316,14 +337,14 @@ void PowersWithoutPowersWorklist::speedUpTable(unsigned long minK, unsigned long
 }
 #endif  //_OPENMP
 
-
 void PowersWithoutPowersWorklist::printStatistics([[maybe_unused]] unsigned long max_level) {
-  #ifdef STATS
+#ifdef STATS
   printf("%5s|%5s|%14s|%14s\n", "Level", "Max K", "Max K Exponent", "worklist_size");
   for (unsigned i = 0; i < max_level; i++) {
     printf("%5u|%5u|%14lu|%14u\n", i + 1, max_k[i], max_k_number[i], worklist_size[i]);
   }
-  cout << "\n" << "Complete: " << (isComplete() ? "Yes" : "No") << "\n" << "Matches: " << matches << "\n";
-  #endif  // STATS
+  cout << "\n"
+       << "Complete: " << (isComplete() ? "Yes" : "No") << "\n"
+       << "Matches: " << matches << "\n";
+#endif  // STATS
 }
-

--- a/src/PowersWithoutPowersWorklist.hpp
+++ b/src/PowersWithoutPowersWorklist.hpp
@@ -12,13 +12,13 @@ using std::vector;
 class PowersWithoutPowersWorklist {
  public:
   unsigned long base = 2;  //!< The base B for the power series. Do NOT CHANGE. Not yet supported
-  array<bool, 10> forbiddenDigits = {false, true, true, false, true, false, false, false, true, false};  //!< The Set Ŝ of forbidden Digits
-
+  array<bool, NUM_DIGITS_ST> forbiddenDigits = {false, true,  true,  false, true,
+                                                false, false, false, true,  false};  //!< The Set Ŝ of forbidden Digits
   unsigned int level = 1;                                  //!< The level (k) of the suffix class tree which we are
                                                            //!< currently processing
   array<vector<unsigned long>, K_MAX_FOR_ULONG> worklist;  //!< Each worklist belongs to one level
   vector<unsigned long> unexpanded;                        //!< n for which 2^n has legal suffix longer than 27 =>
-                                                           //!< children > max<ulong>()
+                                                           //!< children > max<unsigned long>()
   vector<unsigned long> matches;                           //!< matches found during run
   PowersWithoutPowersWorklist() { worklist[0] = {1, 2, 3, 4}; };
 
@@ -57,11 +57,11 @@ class PowersWithoutPowersWorklist {
    */
   auto isComplete() -> bool;
 
-  static void timeTableRun(unsigned long maxK = 14);
+  static void timeTableRun(unsigned long maxK = 14);  // NOLINT
 #ifdef _OPENMP
-  static void timeTableRunParallel(unsigned long maxK = 14);
-  static void speedUpTable(unsigned long minK = 13, unsigned long maxK = 16);
-#endif  //_OPENMP
+  static void timeTableRunParallel(unsigned long maxK = 14);                   // NOLINT
+  static void speedUpTable(unsigned long minK = 13, unsigned long maxK = 16);  // NOLINT
+#endif                                                                         //_OPENMP
 
 #ifdef STATS
   array<unsigned, K_MAX_FOR_ULONG> max_k{};
@@ -72,7 +72,7 @@ class PowersWithoutPowersWorklist {
 
  private:
   inline auto getWL(unsigned long _level) -> vector<unsigned long>& { return worklist.at(_level - 1); }
-  inline auto isInWLRange(unsigned long _level) -> bool { return 0 < _level and _level <= K_MAX_FOR_ULONG; }
+  static inline auto isInWLRange(unsigned long _level) -> bool { return 0 < _level and _level <= K_MAX_FOR_ULONG; }
 
   /** Adds the first expansion of [r]_{k} to the end of the specified worklist
    * The nth expansion of [r]_{k} is [x | x in [r]_{k}, cycleStart (k+n) <= x <=
@@ -80,7 +80,7 @@ class PowersWithoutPowersWorklist {
    * k \param k level of the parent \param k_child level of the child to be
    * expanded \param worklist where the children will be added
    */
-  inline void expand1(unsigned long r, unsigned long k, vector<unsigned long>& worklist);
+  static inline void expand1(unsigned long r, unsigned long k, vector<unsigned long>& worklist);
 
   /** Adds the (k_child - k) expansion of [r]_{k} to the end of the specified
    * worklist The nth expansion of [r]_{k} is [x | x in [r]_{k}, cycleStart
@@ -88,5 +88,5 @@ class PowersWithoutPowersWorklist {
    * r <= cycleLast k \param k level of the parent \param worklist where the
    * children will be added
    */
-  inline void expand(unsigned long r, unsigned long k, unsigned long k_child, vector<unsigned long>& worklist);
+  static inline void expand(unsigned long r, unsigned long k, unsigned long k_child, vector<unsigned long>& worklist);
 };

--- a/src/PowersWithoutPowersWorklist_Test.hpp
+++ b/src/PowersWithoutPowersWorklist_Test.hpp
@@ -1,13 +1,15 @@
 #pragma once
 
 #include <gmpxx.h>
+#include <omp.h>
 #include "ExtraOperators.hpp"
 #include "PowersWithoutPowersWorklist.hpp"
 
 namespace PowersWithoutPowersWorklist_Test {
-auto Test() -> bool {
+inline auto Test() -> bool {
   using namespace std;
-  cout << " --- Testing PowersWithoutPowersWorklist --- " << "\n";
+  cout << " --- Testing PowersWithoutPowersWorklist --- "
+       << "\n";
   bool success = true;
   bool test = true;
 
@@ -19,20 +21,20 @@ auto Test() -> bool {
 
   cout << "run (matches): ";
   auto m = pwp.run(1);
-  test = (m.size() == 0);
+  test = (m.empty());
   success &= test;
   cout << ((test ? "success" : "failed")) << "\n";
 
   cout << "run (worklist): ";
-  test = (pwp.worklist[0].size() == 0);
+  test = (pwp.worklist[0].empty());
   test &= (pwp.worklist[1] == vector<unsigned long>({8, 12, 16, 20}));
-  test &= (pwp.worklist[2].size() == 0);
-  test &= (pwp.worklist[3].size() == 0);
+  test &= (pwp.worklist[2].empty());
+  test &= (pwp.worklist[3].empty());
   success &= test;
   cout << ((test ? "success" : "failed")) << "\n";
 
   cout << "run (unexpanded): ";
-  test = (pwp.unexpanded.size() == 0);
+  test = (pwp.unexpanded.empty());
   success &= test;
   cout << ((test ? "success" : "failed")) << "\n";
 
@@ -43,8 +45,8 @@ auto Test() -> bool {
   cout << ((test ? "success" : "failed")) << "\n";
 
   cout << "run2 (worklist): ";
-  test = (pwp.worklist[0].size() == 0);
-  test &= (pwp.worklist[1].size() == 0);
+  test = (pwp.worklist[0].empty());
+  test &= (pwp.worklist[1].empty());
   test &= (pwp.worklist[2].size() == 16);
   test &= (pwp.worklist[3].size() == 12);
   test &= (pwp.worklist[4].size() == 4);
@@ -59,12 +61,12 @@ auto Test() -> bool {
   test &= (pwp.worklist[13].size() == 4);
   test &= (pwp.worklist[14].size() == 4);
   test &= (pwp.worklist[15].size() == 4);
-  test &= (pwp.worklist[16].size() == 0);
+  test &= (pwp.worklist[16].empty());
   success &= test;
   cout << ((test ? "success" : "failed")) << "\n";
 
   cout << "run2 (unexpanded): ";
-  test = (pwp.unexpanded.size() == 0);
+  test = (pwp.unexpanded.empty());
   success &= test;
   cout << ((test ? "success" : "failed")) << "\n";
 
@@ -72,7 +74,8 @@ auto Test() -> bool {
 #ifdef _OPENMP
   for (int n : {1, 2, 4, 8, 12, 48}) {
     omp_set_num_threads(n);
-    cout << "OMP_NUM_THREADS=" << n << "\n" << "runParallel:";
+    cout << "OMP_NUM_THREADS=" << n << "\n"
+         << "runParallel:";
 
     PowersWithoutPowersWorklist pwp2;
     m = pwp2.runParallel(10);
@@ -113,7 +116,8 @@ auto Test() -> bool {
   }
 #endif  //_OPENMP
 
-  cout << " --- Overall " << (success ? "success --- " : "failed --- ") << "\n" << "\n";
+  cout << " --- Overall " << (success ? "success --- " : "failed --- ") << "\n"
+       << "\n";
   return success;
 }
 }  // namespace PowersWithoutPowersWorklist_Test

--- a/src/Stats.cpp
+++ b/src/Stats.cpp
@@ -1,5 +1,7 @@
 #include "Stats.hpp"
 
+#ifdef STATS
 Integer Stats::maxK = 0;
 Integer Stats::maxLen = 0;
 Integer Stats::maxMod = 0;
+#endif

--- a/src/Stats.hpp
+++ b/src/Stats.hpp
@@ -6,9 +6,11 @@
 using Integer = mpz_class;
 #include <iostream>
 struct Stats {
+#ifdef STATS
   static Integer maxK;
   static Integer maxLen;
   static Integer maxMod;
+#endif
 
   inline static void updateK([[maybe_unused]] const Integer& k) {
 #ifdef STATS

--- a/src/SuffixClass.cpp
+++ b/src/SuffixClass.cpp
@@ -9,8 +9,9 @@
 using namespace std;
 
 SuffixClass::SuffixClass(const Integer& k, const Integer& nORr, bool isN) {
-  if (not k.fits_ulong_p())
+  if (not k.fits_ulong_p()) {
     throw std::domain_error("Suffix of length k > 2^64 not supported");
+  }
   _k = k;
   _min = SuffixMath::cycleStart_I(k.get_ui());
   _mod = SuffixMath::cycleLen_I(k.get_ui());
@@ -31,18 +32,6 @@ SuffixClass::SuffixClass(const Integer& k, const Integer& nORr, bool isN) {
     throw std::domain_error("n is not the smallest representative of this class");
   }
 #endif
-}
-
-auto SuffixClass::getSuffixLen() -> const Integer {
-  return _k;  // copy _k
-}
-
-auto SuffixClass::getCycleLen() -> const Integer {
-  return _mod;  // copy _mod
-}
-
-auto SuffixClass::getRepresentativeN() -> const Integer {
-  return _res;  // copy _res
 }
 
 auto SuffixClass::contains(const Integer& n) -> bool {
@@ -70,7 +59,8 @@ auto operator>>(std::istream& is, SuffixClass& obj) -> std::istream& {
   is >> tmp;  // )
   obj._min = SuffixMath::cycleStart(obj._k.get_ui());
 
-  if ((not obj._k.fits_ulong_p()) or (obj._res < obj._min) or (obj._mod != SuffixMath::cycleLen(obj._k.get_ui())))
+  if ((not obj._k.fits_ulong_p()) or (obj._res < obj._min) or (obj._mod != SuffixMath::cycleLen(obj._k.get_ui()))) {
     is.setstate(std::istream::failbit);
+  }
   return is;
 }

--- a/src/SuffixClass.hpp
+++ b/src/SuffixClass.hpp
@@ -18,8 +18,7 @@ class SuffixClass {
   Integer _res = 0;  // residuum such that 2^n % _mod = _res
   Integer _n = 0;    // (not yet smallest) representative of the class
  public:
-  SuffixClass(){};
-
+  SuffixClass() = default;
   /** Represents the Suffix [n]_k whith n in [n]_k
   @param k length of the suffix
   @param n exponent of one representative of the class [n]_k
@@ -28,20 +27,28 @@ class SuffixClass {
   */
   SuffixClass(const Integer& k, const Integer& nORr, bool isN = true);
 
-  const Integer getSuffixLen();
-  const Integer getCycleLen();
-  const Integer getRepresentativeN();
+  auto getSuffixLen() -> Integer {
+    return _k;  // copy _k
+  }
 
-  bool contains(const Integer& n);
+  auto getCycleLen() -> Integer {
+    return _mod;  // copy _mod
+  }
 
-  friend bool operator==(const SuffixClass& lhs, const SuffixClass& rhs) { return lhs._k == rhs._k and lhs._res == rhs._res; };
-  friend bool operator!=(const SuffixClass& lhs, const SuffixClass& rhs) { return not(lhs == rhs); };
-  friend bool operator<=(const SuffixClass& lhs, const SuffixClass& rhs) {
+  auto getRepresentativeN() -> Integer {
+    return _res;  // copy _res
+  }
+
+  auto contains(const Integer& n) -> bool;
+
+  friend auto operator==(const SuffixClass& lhs, const SuffixClass& rhs) -> bool { return lhs._k == rhs._k and lhs._res == rhs._res; };
+  friend auto operator!=(const SuffixClass& lhs, const SuffixClass& rhs) -> bool { return not(lhs == rhs); };
+  friend auto operator<=(const SuffixClass& lhs, const SuffixClass& rhs) -> bool {
     return lhs._k <= rhs._k or lhs._res <= rhs._res;
   };  // Sorts for k first then for r
-  friend bool operator<(const SuffixClass& lhs, const SuffixClass& rhs) {
+  friend auto operator<(const SuffixClass& lhs, const SuffixClass& rhs) -> bool {
     return lhs._k < rhs._k or lhs._res < rhs._res;
   };  // Sorts for k first then for r
-  friend std::ostream& operator<<(std::ostream& os, const SuffixClass& obj);
-  friend std::istream& operator>>(std::istream& is, SuffixClass& obj);
+  friend auto operator<<(std::ostream& os, const SuffixClass& obj) -> std::ostream&;
+  friend auto operator>>(std::istream& is, SuffixClass& obj) -> std::istream&;
 };

--- a/src/SuffixClass_Test.hpp
+++ b/src/SuffixClass_Test.hpp
@@ -4,9 +4,10 @@
 #include <sstream>
 #include "SuffixClass.hpp"
 namespace SuffixClass_Test {
-bool Test() {
+inline auto Test() -> bool {
   using namespace std;
-  cout << " --- Testing SuffixClass --- " << "\n";
+  cout << " --- Testing SuffixClass --- "
+       << "\n";
   bool success = true;
   bool test = true;
 
@@ -17,12 +18,12 @@ bool Test() {
   cout << ((test ? "success" : "failed")) << "\n";
 
   cout << "contains: ";
-  test = endsWithTwo.contains(1);
-  test &= endsWithTwo.contains(5);
-  test &= endsWithTwo.contains(9);
-  test &= endsWithTwo.contains(1001);
-  test &= not endsWithTwo.contains(1002);
-  test &= not endsWithTwo.contains(4);
+  test = endsWithTwo.contains(1);          // NOLINT
+  test &= endsWithTwo.contains(5);         // NOLINT
+  test &= endsWithTwo.contains(9);         // NOLINT
+  test &= endsWithTwo.contains(1001);      // NOLINT
+  test &= not endsWithTwo.contains(1002);  // NOLINT
+  test &= not endsWithTwo.contains(4);     // NOLINT
   success &= test;
   cout << (test ? "success" : "failed") << "\n";
 
@@ -71,7 +72,8 @@ bool Test() {
   success &= test;
   cout << (test ? "success" : "failed") << "\n";
 
-  cout << " --- Overall " << (success ? "success --- " : "failed --- ") << "\n" << "\n";
+  cout << " --- Overall " << (success ? "success --- " : "failed --- ") << "\n"
+       << "\n";
   return success;
 }
 }  // namespace SuffixClass_Test

--- a/src/SuffixMath.cpp
+++ b/src/SuffixMath.cpp
@@ -11,7 +11,6 @@
 using namespace std;
 
 const unsigned long NUM_HARDCODED = 50;
-const Integer SIZE_I = NUM_HARDCODED;
 const std::array<const Integer, NUM_HARDCODED> Len_I = {4_mpz,
                                                         20_mpz,
                                                         100_mpz,
@@ -64,22 +63,17 @@ const std::array<const Integer, NUM_HARDCODED> Len_I = {4_mpz,
                                                         71054273576010018587112426757812500_mpz
 
 };
-auto SuffixMath::cycleLen_I(unsigned long k) -> const Integer {
+auto SuffixMath::cycleLen_I(unsigned long k) -> Integer {
   if (k <= NUM_HARDCODED) {
     return Len_I[k - 1];
-  } else {
-    throw std::overflow_error("nooo");
   }
+  throw std::overflow_error("SuffixMath::cycleLen_I called with k > NUM_HARDCODED");
 }
 
 auto SuffixMath::maxCompletedCycleK(unsigned long n) -> unsigned long {
   unsigned long k = 0;
-  while (true) {
-    if (not cycleLastOverflow(k + 1) and cycleLast(k + 1) <= n) {
-      k++;
-    } else {
-      break;
-    }
+  while (not cycleLastOverflow(k + 1) and cycleLast(k + 1) <= n) {
+    k++;
   }
   return k;
 }
@@ -90,22 +84,24 @@ auto SuffixMath::nextCompletedCycleN(unsigned long n) -> unsigned long {
   return SuffixMath::cycleLast(maxCompletedCycleK(n) + 1);
 }
 
-auto SuffixMath::powContainsPows(const Integer& b, const Integer& n) -> const Integer {
-  std::vector<int> powers;
-  for (int p = 1; p < 10; p *= (int)b.get_si()) {
-    powers.push_back(p);
+auto SuffixMath::powContainsPows(const Integer& b, const Integer& n) -> Integer {
+  array<bool, NUM_DIGITS_ST> powers = {false, false, false, false, false, false, false, false, false, false};
+  for (size_t p = 1; p < NUM_DIGITS_ST; p *= b.get_ui()) {
+    powers[p] = true;
   }
   return powContains(powers, b, n);
 }
 
-auto SuffixMath::powContains(const vector<int>& digits, const Integer& b, const Integer& n) -> const Integer {
-  array<bool, 10> forbidden = {false, false, false, false, false, false, false, false, false, false};
-  for (int i : digits)
+auto SuffixMath::powContains(const vector<int>& digits, const Integer& b, const Integer& n) -> Integer {
+  array<bool, NUM_DIGITS_ST> forbidden = {false, false, false, false, false, false, false, false, false, false};
+  for (int i : digits) {
     forbidden[i] = true;
+  }
   return powContains(forbidden, b, n);
 }
 
-auto SuffixMath::powContains(const array<bool, 10>& forbidden, const Integer& b, const Integer& n) -> const Integer {
+// NOLINTBEGIN since here comes a lot of interaction with C Library
+auto SuffixMath::powContains(const array<bool, NUM_DIGITS_ST>& forbidden, const Integer& b, const Integer& n) -> Integer {
   // cout << "powContains(forbidden = [";
   // for (auto i: forbidden)
   // cout << i << " ";
@@ -116,43 +112,29 @@ auto SuffixMath::powContains(const array<bool, 10>& forbidden, const Integer& b,
   // cout << "max_num_digits " << max_num_digits << "\n";
 
   unsigned long m_start = 1,
-                m_stop = 10;  // mpz_pow only supports ulong as exponent
+                m_stop = 10;  // mpz_pow only supports unsigned long as exponent
   while (true) {
-    // cout << "m_start " << m_start << " - m_stop " << m_stop << "\n";
     mpz_t suffix, pow10m, digit;
     mpz_inits(suffix, pow10m, digit, NULL);
-    // cout << "next pow 10 m_stop" << "\n";
-    mpz_ui_pow_ui(pow10m, 10,
-                  m_stop - 1);  // Index starts with 1, exponents with 0 => -1
-    // cout << "mpz" << mpz_get_ui(pow10m) << "\n";
-    // cout << "next pow 10 m_stop" << "\n";
-    mpz_powm(suffix, b.get_mpz_t(), n.get_mpz_t(),
-             pow10m);  // suffix = b^n % 10^m_stop
-    // cout << "next pow 10 m_stop" << "\n";
-    mpz_ui_pow_ui(pow10m, 10,
-                  m_start - 1);  // Index starts with 1, exponents with 0 => -1
-    // cout << "next fdiv 10 m_stop" << "\n";
-    mpz_fdiv_q(suffix, suffix, pow10m);  // suffix = suffix / 10^m_start
-    // cout << "Computed suffix " << mpz_get_ui(suffix) << "\n";
+    mpz_ui_pow_ui(pow10m, 10, m_stop - 1);                   // Index starts with 1, exponents with 0 => -1
+    mpz_powm(suffix, b.get_mpz_t(), n.get_mpz_t(), pow10m);  // suffix = b^n % 10^m_stop
+    mpz_ui_pow_ui(pow10m, 10, m_start - 1);                  // Index starts with 1, exponents with 0 => -1
+    mpz_fdiv_q(suffix, suffix, pow10m);                      // suffix = suffix / 10^m_start
     int d;
     for (unsigned long m = m_start; m < m_stop; m++) {
       d = (int)mpz_tdiv_qr_ui(suffix, digit, suffix,
-                              10);  // suffix = new_suffix * 10 + digit, also returns digit as ulong
-      // cout << d << " ";
+                              10);  // suffix = new_suffix * 10 + digit, also returns digit as unsigned long
       if (forbidden[d]) {
         mpz_clears(suffix, pow10m, digit, NULL);
-        // cout << "Returning " << m << "\n";
-        return m;  //     Return index of forbidden digit
+        return m;  // Return index of forbidden digit
       }
       if (max_num_digits_fits_ui and m >= max_num_digits.get_ui()) {  // Checked all digits from b^n
         mpz_clears(suffix, pow10m, digit, NULL);
-        // cout << "\n" << "Returning " << 0 << "\n";
-        return 0;  //     Return 0 for signaling a match
+        return 0;  // Return 0 for signaling a match
       }
     }
-    // cout << "\n";
     if (m_stop > std::numeric_limits<unsigned long>::max() / 10) {  // b^n has more digits but we cannot check since
-                                                                    // m_stop is bound to ulong
+                                                                    // m_stop is bound to unsigned long
       mpz_clears(suffix, pow10m, digit, NULL);
       throw std::overflow_error(
           "Length of legal digits exceeds <unsigned long>::max(), mpz_pow only "
@@ -163,3 +145,4 @@ auto SuffixMath::powContains(const array<bool, 10>& forbidden, const Integer& b,
     m_stop *= 10;  // Expand 10 times more digits in next loop
   }
 }
+// NOLINTEND

--- a/src/SuffixMath.hpp
+++ b/src/SuffixMath.hpp
@@ -6,14 +6,13 @@
 #include <vector>
 
 using Integer = mpz_class;
-#define K_MAX_FOR_ULONG 27
+
+const int NUM_DIGITS_I = 10;
+const std::size_t NUM_DIGITS_ST = 10;
+
+const unsigned long K_MAX_FOR_ULONG = 27;
 
 namespace SuffixMath {
-const Integer ZERO = 0;
-const Integer ONE = 1;
-const Integer TWO = 2;
-const Integer FOUR = 4;
-const Integer FIVE = 5;
 
 const std::array<const unsigned long, K_MAX_FOR_ULONG> Len_ulong = {4,
                                                                     20,
@@ -43,57 +42,57 @@ const std::array<const unsigned long, K_MAX_FOR_ULONG> Len_ulong = {4,
                                                                     1192092895507812500,
                                                                     5960464477539062500};
 
-inline const Integer cycleStart_I(unsigned long k) {
-  return Integer(k);
+inline auto cycleStart_I(unsigned long k) -> Integer {
+  return {k};
 }
-const Integer cycleLen_I(unsigned long k);
-inline const Integer cycleEnd_I(unsigned long k) {
+auto cycleLen_I(unsigned long k) -> Integer;
+inline auto cycleEnd_I(unsigned long k) -> Integer {
   return cycleStart_I(k) + cycleLen_I(k);
 }
-inline const Integer cycleLast_I(unsigned long k) {
+inline auto cycleLast_I(unsigned long k) -> Integer {
   return cycleStart_I(k) + cycleLen_I(k) - 1;
 }
 
-inline unsigned long cycleStart(unsigned long k) {
+inline auto cycleStart(unsigned long k) -> unsigned long {
   return k;
 }
-inline unsigned long cycleLen(unsigned long k) {
+inline auto cycleLen(unsigned long k) -> unsigned long {
   return Len_ulong[k - 1];
 }
-inline unsigned long cycleEnd(unsigned long k) {
+inline auto cycleEnd(unsigned long k) -> unsigned long {
   return cycleStart(k) + cycleLen(k);
 }
-inline unsigned long cycleLast(unsigned long k) {
+inline auto cycleLast(unsigned long k) -> unsigned long {
   return cycleStart(k) + cycleLen(k) - 1;
 }
 
-inline bool cycleStartOverflow(unsigned long) {
+inline auto cycleStartOverflow(unsigned long /*unused*/) -> bool {
   return false;
 }
-inline bool cycleLenOverflow(unsigned long k) {
+inline auto cycleLenOverflow(unsigned long k) -> bool {
   return k > K_MAX_FOR_ULONG;
 }
-inline bool cycleEndOverflow(unsigned long k) {
+inline auto cycleEndOverflow(unsigned long k) -> bool {
   return k > K_MAX_FOR_ULONG;
 }
-inline bool cycleLastOverflow(unsigned long k) {
+inline auto cycleLastOverflow(unsigned long k) -> bool {
   return k > K_MAX_FOR_ULONG;
 }
 
 /**
 @return biggest k such that cycleLast(k) <= n
 */
-unsigned long maxCompletedCycleK(unsigned long n);
+auto maxCompletedCycleK(unsigned long n) -> unsigned long;
 
 /**
 @return biggest integer n_k <= n where n_k is the end of a cycle
 */
-unsigned long maxCompletedCycleN(unsigned long n);
+auto maxCompletedCycleN(unsigned long n) -> unsigned long;
 
 /**
 @return smallest integer n_k > n where n_k is the end of a cycle
 */
-unsigned long nextCompletedCycleN(unsigned long n);
+auto nextCompletedCycleN(unsigned long n) -> unsigned long;
 
 /**
 @param digits The list of forbidden digits
@@ -102,7 +101,7 @@ unsigned long nextCompletedCycleN(unsigned long n);
 @return the smallest index k where a forbidden digit was found, 0 if b^n does
 not contain any forbidden digits
 */
-const Integer powContains(const std::vector<int>& digits, const Integer& b, const Integer& n);
+auto powContains(const std::vector<int>& digits, const Integer& b, const Integer& n) -> Integer;
 
 /**
 @param forbidden mask for forbidden digits s.t. forbidden[i] == true means i is
@@ -112,7 +111,7 @@ a forbidden digit
 @return the smallest index k where a forbidden digit was found, 0 if b^n does
 not contain any forbidden digits
 */
-const Integer powContains(const std::array<bool, 10>& forbidden, const Integer& b, const Integer& n);
+auto powContains(const std::array<bool, NUM_DIGITS_ST>& forbidden, const Integer& b, const Integer& n) -> Integer;
 
 /** forbidden digits are all powers of b that are smaller than 10
 @param b base
@@ -120,6 +119,6 @@ const Integer powContains(const std::array<bool, 10>& forbidden, const Integer& 
 @return the smallest index k where a forbidden digit was found, 0 if b^n does
 not contain any forbidden digits
 */
-const Integer powContainsPows(const Integer& b, const Integer& n);
+auto powContainsPows(const Integer& b, const Integer& n) -> Integer;
 
 }  // namespace SuffixMath

--- a/src/SuffixMath_Test.hpp
+++ b/src/SuffixMath_Test.hpp
@@ -2,11 +2,13 @@
 
 #include <iostream>
 #include "SuffixMath.hpp"
+// NOLINTBEGIN because of intended magic numbers
 namespace SuffixMath_Test {
-bool Test() {
+inline auto Test() -> bool {
   using namespace std;
   using namespace SuffixMath;
-  cout << " --- Testing SuffixMath --- " << "\n";
+  cout << " --- Testing SuffixMath --- "
+       << "\n";
   bool success = true;
   bool test = true;
 
@@ -101,7 +103,9 @@ bool Test() {
   success &= test;
   cout << ((test ? "success" : "failed")) << "\n";
 
-  cout << " --- Overall " << (success ? "success --- " : "failed --- ") << "\n" << "\n";
+  cout << " --- Overall " << (success ? "success --- " : "failed --- ") << "\n"
+       << "\n";
   return success;
 }
 }  // namespace SuffixMath_Test
+   // NOLINTEND

--- a/src/SuffixSet.cpp
+++ b/src/SuffixSet.cpp
@@ -4,51 +4,52 @@
 #include <stdexcept>
 #include "SuffixMath.hpp"
 
-SuffixSet::SuffixSet() {}
-SuffixSet::~SuffixSet() {}
-
 auto SuffixSet::modCk(unsigned long n, unsigned long k) -> unsigned long {
-  if (SuffixMath::cycleLenOverflow(k))
+  if (SuffixMath::cycleLenOverflow(k)) {
     return n;
-  else
-    return n % SuffixMath::cycleLen(k);
+  }
+  return n % SuffixMath::cycleLen(k);
 }
 
 void SuffixSet::insert(unsigned long n, unsigned long k) {
   setRK.insert(std::make_pair(modCk(n, k), k));
-  if (k > maxK)
+  if (k > maxK) {
     maxK = k;
+  }
 }
-void SuffixSet::insert(Integer n, Integer k) {
-  if (n.fits_ulong_p() && k.fits_ulong_p())
+void SuffixSet::insert(const Integer& n, const Integer& k) {
+  if (n.fits_ulong_p() && k.fits_ulong_p()) {
     insert(n.get_ui(), k.get_ui());
-  else
+  } else {
     throw std::domain_error("Not yet implemented for n or k => 2^64");
+  }
 }
 
 auto SuffixSet::containsN(unsigned long n) -> bool {
   for (unsigned long k = 1; k <= std::min(maxK, n); k++) {
     unsigned long m = modCk(n, k);
     auto i = setRK.find(std::make_pair(m, k));
-    if (i != setRK.end())
+    if (i != setRK.end()) {
       return true;
+    }
   }
   return false;
 }
-auto SuffixSet::containsN(Integer n) -> bool {
-  if (n.fits_ulong_p())
+auto SuffixSet::containsN(const Integer& n) -> bool {
+  if (n.fits_ulong_p()) {
     return containsN(n.get_ui());
-  else
-    throw std::domain_error("Not yet implemented for n => 2^64");
+  }
+  throw std::domain_error("Not yet implemented for n => 2^64");
 }
 
-auto SuffixSet::toVector() -> std::vector<SuffixClass> {
-  Integer k_I, r_I;
+auto SuffixSet::toVector() const -> std::vector<SuffixClass> {
+  Integer k_I;
+  Integer r_I;
   std::vector<SuffixClass> res;
   for (auto p : setRK) {
     r_I = std::get<0>(p);
     k_I = std::get<1>(p);
-    res.push_back(SuffixClass(k_I, r_I, false));
+    res.emplace_back(k_I, r_I, false);
   }
   return res;
 }

--- a/src/SuffixSet.hpp
+++ b/src/SuffixSet.hpp
@@ -13,9 +13,6 @@ using Integer = mpz_class;
  */
 class SuffixSet {
  public:
-  SuffixSet();
-  ~SuffixSet();
-
   /** Adds the suffix class [n]_k to the container
   @param k length of the suffix
   @param n exponent of one representative of the class
@@ -26,36 +23,37 @@ class SuffixSet {
   @param k length of the suffix
   @param n exponent of one representative of the class
   */
-  void insert(Integer n, Integer k);
+  void insert(const Integer& n, const Integer& k);
 
   /** Adds the suffix class [n]_k to the container
   @param k length of the suffix
   @param n exponent of one representative of the class
   @return true iff N is in any suffix class [r]_k that was previously added
   */
-  bool containsN(unsigned long n);
+  [[nodiscard]] auto containsN(unsigned long n) -> bool;
 
   /** Test if this set contains n
   @param k length of the suffix
   @param n exponent of one representative of the class
   @return true iff n is in any suffix class [r]_k that was previously added
   */
-  bool containsN(Integer n);
+  auto containsN(const Integer& n) -> bool;
 
   /**
   @return the maximal k of all classes [r]_k that are in this set
   */
-  unsigned long getMaxK() { return maxK; };
+  [[nodiscard]] auto getMaxK() const -> unsigned long { return maxK; };
 
   /**
   @return an equivalent representation of this set in form of a vector
   */
-  std::vector<SuffixClass> toVector();
+  [[nodiscard]] auto toVector() const -> std::vector<SuffixClass>;
 
  private:
   struct rk_hash {
-    inline std::size_t operator()(const std::pair<unsigned long, unsigned long>& p) const {
-      return (std::size_t)(p.first ^ (p.second << 56));  // k in [1..256] = [1..2^8] -> 2^56 * k < 2^64
+    inline auto operator()(const std::pair<unsigned long, unsigned long>& p) const -> std::size_t {
+      const auto SHIFT_FACTOR = 56;  // k in [1..256] = [1..2^8] -> 2^56 * k < 2^64
+      return (std::size_t)(p.first ^ (p.second << SHIFT_FACTOR));
     }
   };
 
@@ -63,7 +61,7 @@ class SuffixSet {
   unsigned long maxK = 0;
 
   // Computes r = n mod cycleLen(k), takes care of wrapping and unwrapping
-  unsigned long modCk(unsigned long n, unsigned long r);
+  static auto modCk(unsigned long n, unsigned long k) -> unsigned long;
 };
 
 #endif  // SUFFIXSET_H

--- a/src/SuffixSet.hpp
+++ b/src/SuffixSet.hpp
@@ -61,14 +61,6 @@ class SuffixSet {
 
   ska::flat_hash_set<std::pair<unsigned long, unsigned long>, rk_hash> setRK;
   unsigned long maxK = 0;
-  // Preventing reallocation by providing
-  mpz_t TWO;   // constant base used for operations like powMod
-  mpz_t op1;   // buffers for the arguments of operations like powMod
-  mpz_t op2;   // buffers for the arguments of operations like powMod
-  mpz_t rop;   // buffers for the results of operations like powMod
-  Integer i1;  // buffer for arguments of operations like cycleLen
-  Integer i2;  // buffer for arguments of operations like cycleLen
-  Integer i3;  // buffer for arguments of operations like cycleLen
 
   // Computes r = n mod cycleLen(k), takes care of wrapping and unwrapping
   unsigned long modCk(unsigned long n, unsigned long r);

--- a/src/SuffixSet_Test.hpp
+++ b/src/SuffixSet_Test.hpp
@@ -4,9 +4,10 @@
 #include <iostream>
 #include "SuffixSet.hpp"
 namespace SuffixSet_Test {
-bool Test() {
+inline auto Test() -> bool {
   using namespace std;
-  cout << " --- Testing SuffixSet --- " << "\n";
+  cout << " --- Testing SuffixSet --- "
+       << "\n";
   bool success = true;
   bool test = true;
 
@@ -24,17 +25,19 @@ bool Test() {
   cout << (test ? "success" : "failed") << "\n";
 
   cout << "contains [0..30]: ";
-  const std::array<bool, 30> member = {false, true,  true,  true,  false, true,  false, false, false, true,
-                                       false, false, false, true,  false, false, false, true,  false, false,
-                                       false, true,  true,  false, false, true,  false, false, false, true};
+  const unsigned long TEST_N_MAX = 30;
+  const std::array<bool, TEST_N_MAX> member = {false, true,  true,  true,  false, true,  false, false, false, true,
+                                               false, false, false, true,  false, false, false, true,  false, false,
+                                               false, true,  true,  false, false, true,  false, false, false, true};
   test = true;
-  for (unsigned long n = 0; n < 30; n++) {
+  for (unsigned long n = 0; n < TEST_N_MAX; n++) {
     test &= (s.containsN(n) == member[n]);
   }
   success &= test;
   cout << (test ? "success" : "failed") << "\n";
 
-  cout << " --- Overall " << (success ? "success --- " : "failed --- ") << "\n" << "\n";
+  cout << " --- Overall " << (success ? "success --- " : "failed --- ") << "\n"
+       << "\n";
   return success;
 }
 }  // namespace SuffixSet_Test

--- a/src/config.hpp.in
+++ b/src/config.hpp.in
@@ -1,7 +1,8 @@
 #pragma once
-
+// clang-format off
 #define PWP_VERSION_MAJOR @PWP_VERSION_MAJOR@
 #define PWP_VERSION_MINOR @PWP_VERSION_MINOR@
 #define PWP_VERSION @PWP_VERSION@
 #cmakedefine STATS
 #cmakedefine TEST
+// clang-format on

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -40,9 +40,11 @@ void printWelcome() {
 
 void printHelp() {
 #ifdef _OPENMP
-  cout << "Usage: pwp (bench <min> <max>|run <max> [-s|-p])" << "\n";
+  cout << "Usage: pwp (bench <min> <max>|run <max> [-s|-p])"
+       << "\n";
 #else
-  cout << "Usage: pwp run <max>" << "\n";
+  cout << "Usage: pwp run <max>"
+       << "\n";
 #endif  //_OPENMP
 #pragma omp master
   std::exit(ERROR_INVALID_ARGUMENTS);
@@ -143,7 +145,8 @@ auto main() -> int {
   success &= PowersWithoutPowersFinder_Test::Test();
   success &= PowersWithoutPowersWorklist_Test::Test();
 
-  cout << " === Testsuite " << (success ? "succeeded === " : "failed === ") << "\n" << "\n";
+  cout << " === Testsuite " << (success ? "succeeded === " : "failed === ") << "\n"
+       << "\n";
   return success ? SUCCESS : ERROR_PWP_TESTS_FAILED;
 }
 #else


### PR DESCRIPTION
- Updated standard to c++17
- Protected CMAKE placeholders from clang-format
- Excluded clang-tidy checks that cause to many false positives
- Switched to trailing return types
- Fixed many issues raised by cland-tidy checks
- Excluded some lines from linting if they are known false positives